### PR TITLE
Fix bug sélecteur de durée

### DIFF
--- a/src/data/appliances.json
+++ b/src/data/appliances.json
@@ -84,7 +84,7 @@
     "power": 1000,
     "defaultOccurence": {
       "start": 18,
-      "duration": 0.09,
+      "duration": 0.0833333333333339,
       "allDay": false
     },
     "durationSelector": true,
@@ -108,7 +108,7 @@
     "power": 1300,
     "defaultOccurence": {
       "start": 12,
-      "duration": 0.09,
+      "duration": 0.0833333333333339,
       "allDay": false
     },
     "durationSelector": true,
@@ -120,7 +120,7 @@
     "power": 2000,
     "defaultOccurence": {
       "start": 8,
-      "duration": 0.09,
+      "duration": 0.0833333333333339,
       "allDay": false
     },
     "durationSelector": true,


### PR DESCRIPTION
Il y avait un soucis pour les appareils ayant une durée par défaut de 5 minutes, j'avais mis 0.09h alors que dans les options de durée, les 5 minutes sont approximées à 0.0833333333333339. 

il y a peut-être un truc à gérer à ce niveau là (minutes vs heures pour les specs des appareils)